### PR TITLE
Token display

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for Token {
             Token::LOr => write!(f, "or"),
             Token::Bang => write!(f, "!"),
             Token::StringLit(n) => write!(f, "{n}"),
-            Token::NumLit(n) => write!(f, "{n}"),
+            Token::NumLit(n) => write!(f, "\"{n}\""),
             Token::Ident(n) => write!(f, "ident[{n}]"),
         }
     }


### PR DESCRIPTION
Implemented display for token. It writes the keyword or symbol the group agreed upon for each keyword token, the string itself for a string literal, the number for a float, and indent[string] for an identifier.