### PR TITLE
feat: print function calls

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -84,7 +84,7 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 match fn_name.as_str() {
                     "print" => {
                         let [first] = &args[..] else { panic!() };
-                        writeln!(self.output, "{:?}", first);
+                        writeln!(self.output, "{}", first);
                         RuntimeVal::Null
                     }
                     _ => panic!(""),


### PR DESCRIPTION
# Major
- call_function evaluates print function
- prints out `n` args, as is
TODO: Proper formatting for strings, vectors, etc.

## Minor
- Added `Function` and `Null` to `RuntimeVal`
 