### PR TITLE
Modify consume_args to error if commas are omitted

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -114,15 +114,16 @@ impl<I: Iterator<Item = Token>> Parser<I> {
     fn consume_args(&mut self) -> Vec<Expr> {
         let mut args_vec = vec![];
 
-        while self.matches(Token::Comma)
-            || (self
-                .stream
-                .peek()
-                .is_some_and(|tok| tok != &Token::CloseParen))
-        {
+        if !self.matches(Token::CloseParen) {
             args_vec.push(self.parse());
+            while self.matches(Token::Comma) {
+                args_vec.push(self.parse());
+            }
+            self.consume(
+                Token::CloseParen,
+                "Unclosed function call parentheses or missing comma",
+            );
         }
-        self.consume(Token::CloseParen, "Function call parentheses not closed");
 
         args_vec
     }


### PR DESCRIPTION
This PR corrects issue #27.

The functions `consume_args` in `parser.rs` has been modified to panic if commas are omitted between arguments. Due to the nature of this error condition, the error is reported the same as if the closing parentheses was omitted. The error message has been updated to reflect this. The behavior of the function otherwise remains the same.