### PR TITLE
Parser: Add Semicolon Requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,10 @@ mod tests {
 
     #[test]
     fn basic() {
-        assert_eq!(harness("print(4)"), "4\n");
-        assert_eq!(harness("print(4 + 5)"), "9\n");
-        assert_eq!(harness("print(4 * 5)"), "20\n");
-        assert_eq!(harness("print(7 + 4 * 5)"), "27\n");
-        assert_eq!(harness("print((7 + 4) * 5)"), "55\n");
+        assert_eq!(harness("print(4);"), "4\n");
+        assert_eq!(harness("print(4 + 5);"), "9\n");
+        assert_eq!(harness("print(4 * 5);"), "20\n");
+        assert_eq!(harness("print(7 + 4 * 5);"), "27\n");
+        assert_eq!(harness("print((7 + 4) * 5);"), "55\n");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,7 +84,8 @@ impl<I: Iterator<Item = Token>> Parser<I> {
     pub fn parse(&mut self) -> (Vec<Expr>, usize) {
         let mut exprs = vec![];
         while self.stream.peek().is_some() {
-            exprs.push(self.parse_expr())
+            exprs.push(self.parse_expr());
+            self.consume(Token::Semi, "Expected ';' after expression");
         }
         (exprs, self.next_index)
     }
@@ -389,6 +390,7 @@ mod tests {
         assert_eq!(parser.parse_expr(), target);
     }
 
+    #[test]
     pub fn test_unary_and_minus() {
         let mut parser = Parser::new(
             [
@@ -405,13 +407,14 @@ mod tests {
                 operation: UnaryOp::Negate,
                 right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
             }),
-            operation: BinaryOp::Add,
+            operation: BinaryOp::Subtract,
             right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
         };
 
         assert_eq!(parser.parse_expr(), target);
     }
 
+    #[test]
     pub fn test_unary_with_parens() {
         let mut parser = Parser::new(
             [

--- a/src/src.txt
+++ b/src/src.txt
@@ -1,5 +1,4 @@
-let a = 4
-let b = 5
-print(a)
-print(b)
-
+let a = 4;
+let b = 5;
+print(a);
+print(b);


### PR DESCRIPTION
* Consumes a semicolon after every expression is parsed.
* Fixed all tests to include semicolons