### PR TITLE
Feat/interpreter/if statements

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -279,18 +279,24 @@ mod tests {
     }
 
     #[test]
-     fn test_interpreter() {
+    fn test_interpreter() {
         let mut out = vec![];
 
         let func_name = String::from("print");
 
-        let expr = Expr::Call {callee: Box::new(Expr::Ident(func_name)),args: vec![Expr::Literal(RuntimeVal::Number(5.0))]};
+        let expr = Expr::Call {
+            callee: Box::new(Expr::Ident(func_name)),
+            args: vec![Expr::Literal(RuntimeVal::Number(5.0))],
+        };
 
         let mut interpreter = Interpreter::new(&mut out, 0);
         let res = interpreter.evaluate(&expr);
 
-        assert_eq!(String::from_utf8(out).expect("failed to read from out"), String::from("5\n"));
-     }
+        assert_eq!(
+            String::from_utf8(out).expect("failed to read from out"),
+            String::from("5\n")
+        );
+    }
 
     #[test]
     fn test_binary_ops_int() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -143,7 +143,6 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         expr
     }
 
-
     fn parse_if(&mut self) -> Expr {
         let cond = self.parse_expr();
         self.consume(Token::OpenBracket, "Expected '{' after if condition");
@@ -196,7 +195,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         );
         self.env.pop().expect("misaligned environment stack");
         Expr::Block(exprs)
-  }
+    }
 
     fn parse_comparisons(&mut self) -> Expr {
         let left = self.parse_add_subtract();
@@ -728,7 +727,7 @@ mod tests {
         };
 
         assert_eq!(parsed, target);
-  }
+    }
     pub fn test_comparisons() {
         let comparison_operations = [
             (Token::EqEq, BinaryOp::Equal),

--- a/src/src.txt
+++ b/src/src.txt
@@ -1,7 +1,7 @@
-if 1 {
+if 1 == 0 {
     print("one");
     "one";
-} otherwise if 2 {
+} otherwise if 2 == 0 {
     print("two");
     "two";
 };


### PR DESCRIPTION
# Major
- interpreter support for: `==`, `!=`, `>`, `<`, `>=`, and `<=`
- if/otherwise statement interpreting. If statements w/o otherwise branch evalue to `RuntimeVal::Null`

## Minor
- evaluate blocks line by line
- empty blocks evaluate to `RuntimeVal::Null`
- non-empty blocks evaluate to last statement in them

### Testing
- wrote tests for literal, all binary operations (including those introduced in #38)
- test for literal output of print from interpreter
- test both unary operations

important: re: #39 

## Fixes
- fixed fractional check in BitNot negate