### PR TITLE
Feat/interpreter/rc string

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -54,7 +54,7 @@ impl<'a, W: Write> Interpreter<'a, W> {
             (RuntimeVal::String(mut s1), RuntimeVal::Number(n)) => {
                 assert!(n.fract() != 0.0, "You can't multiply a string by a float!");
 
-                let st = format!("{s1}").repeat(n as usize);
+                let st  = s1.repeat(n as usize);
 
                 RuntimeVal::String(st.into())
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -39,8 +39,8 @@ impl<'a, W: Write> Interpreter<'a, W> {
     fn operation_add(&self, left: RuntimeVal, right: RuntimeVal) -> RuntimeVal {
         match (left, right) {
             (RuntimeVal::Number(n1), RuntimeVal::Number(n2)) => RuntimeVal::Number(n1 + n2),
-            (RuntimeVal::String(mut s1), RuntimeVal::String(s2)) => {
-                let res = format!("{s1} + {s2}");
+            (RuntimeVal::String(s1), RuntimeVal::String(s2)) => {
+                let res = format!("{s1}{s2}");
 
                 RuntimeVal::String(res.into())
             }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,11 +1,11 @@
-use std::{fmt::Display, io::Write};
+use std::{fmt::Display, io::Write, rc::Rc};
 
 use crate::parser::{BinaryOp, Expr, UnaryOp};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeVal {
     Number(f64),
-    String(String),
+    String(Rc<str>),
     Boolean(bool),
     Function(String),
     Null,
@@ -40,8 +40,9 @@ impl<'a, W: Write> Interpreter<'a, W> {
         match (left, right) {
             (RuntimeVal::Number(n1), RuntimeVal::Number(n2)) => RuntimeVal::Number(n1 + n2),
             (RuntimeVal::String(mut s1), RuntimeVal::String(s2)) => {
-                s1.push_str(&s2);
-                RuntimeVal::String(s1)
+                let res = format!("{s1} + {s2}");
+
+                RuntimeVal::String(res.into())
             }
             _ => panic!("You can't add those, idiot!"), // TODO: Update error messages
         }
@@ -53,9 +54,9 @@ impl<'a, W: Write> Interpreter<'a, W> {
             (RuntimeVal::String(mut s1), RuntimeVal::Number(n)) => {
                 assert!(n.fract() != 0.0, "You can't multiply a string by a float!");
 
-                s1 = s1.repeat(n as usize);
+                let st = format!("{s1}").repeat(n as usize);
 
-                RuntimeVal::String(s1)
+                RuntimeVal::String(st.into())
             }
             _ => panic!("You can't multiply those, idiot!"), // TODO: Update error messages
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -256,7 +256,7 @@ mod tests {
         let mut parser = Parser::new([Token::StringLit("dingus".to_string())].into_iter());
         assert_eq!(
             parser.parse_expr(),
-            Expr::Literal(RuntimeVal::String("dingus".to_string().into()))
+            Expr::Literal(RuntimeVal::String("dingus".into()))
         );
     }
 
@@ -359,7 +359,7 @@ mod tests {
                     Expr::Literal(RuntimeVal::Number(88.0)),
                 ],
             }),
-            args: vec![Expr::Literal(RuntimeVal::String("dingus".to_string().into()))],
+            args: vec![Expr::Literal(RuntimeVal::String("dingus".into()))],
         };
 
         assert_eq!(parser.parse_expr(), target);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -222,7 +222,7 @@ impl<I: Iterator<Item = Token>> Parser<I> {
         let token = self.stream.next().expect("expected basic token, got none");
         match token {
             Token::OpenParen => self.parse_paren(),
-            Token::StringLit(string) => Expr::Literal(RuntimeVal::String(string)),
+            Token::StringLit(string) => Expr::Literal(RuntimeVal::String(string.into())),
             Token::NumLit(number) => Expr::Literal(RuntimeVal::Number(number)),
             Token::Ident(identifier) => self
                 .find_var(&identifier)
@@ -256,7 +256,7 @@ mod tests {
         let mut parser = Parser::new([Token::StringLit("dingus".to_string())].into_iter());
         assert_eq!(
             parser.parse_expr(),
-            Expr::Literal(RuntimeVal::String("dingus".to_string()))
+            Expr::Literal(RuntimeVal::String("dingus".to_string().into()))
         );
     }
 
@@ -359,7 +359,7 @@ mod tests {
                     Expr::Literal(RuntimeVal::Number(88.0)),
                 ],
             }),
-            args: vec![Expr::Literal(RuntimeVal::String("dingus".to_string()))],
+            args: vec![Expr::Literal(RuntimeVal::String("dingus".to_string().into()))],
         };
 
         assert_eq!(parser.parse_expr(), target);


### PR DESCRIPTION
# Major

- Updated `RuntimeVal::String` to `Rc` (e.g. `Rc<str>`) for cheap cloning
- String addition fixed to use `format!()` macro to concatenate strings
- string multiplication fixed to use `format!()` macro to repeat multiple times

## Minor
- coerce strings in `parser.rs` to be `Rc<str>` 