### PR TITLE
Tests: Improve tests with macros and misc improvements

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -76,6 +76,12 @@ pub struct Lexer<I: Iterator<Item = u8>> {
 }
 
 impl<I: Iterator<Item = u8>> Lexer<I> {
+    pub fn new(stream: I) -> Self {
+        Self {
+            stream: stream.peekable(),
+        }
+    }
+
     fn lex_multi_byte(&mut self, first: u8) -> Token {
         let second = self.stream.peek();
         match (first, second) {
@@ -205,14 +211,6 @@ impl<I: Iterator<Item = u8>> Iterator for Lexer<I> {
             };
 
             return Some(tok);
-        }
-    }
-}
-
-impl<I: Iterator<Item = u8>> Lexer<I> {
-    pub fn new(stream: I) -> Self {
-        Self {
-            stream: stream.peekable(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use crate::{interpreter::Interpreter, lexer::Lexer, parser::Parser};
 
 mod interpreter;
 mod lexer;
+mod macros;
 mod parser;
 
 pub fn ferric_main(source: &str) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,88 @@
+#[macro_export]
+macro_rules! one_token {
+    (StrLit($s:expr)) => {
+        Token::StringLit(String::from($s))
+    };
+    (Ident($s:expr)) => {
+        Token::Ident(String::from($s))
+    };
+    ($name:ident$(($($t:tt)*))?) => {
+        Token::$name$(($($t)*))?
+    };
+}
+
+#[macro_export]
+macro_rules! tokens {
+    ($($name:ident$(($($t:tt)*))?),*) => {
+        {
+            [
+                $(
+                    one_token!($name$(($($t)*))?)
+                ),*
+            ]
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! expr {
+    (Null()) => {
+        Expr::Literal(RuntimeVal::Null)
+    };
+    (NumLit($n:expr)) => {
+        Expr::Literal(RuntimeVal::Number($n))
+    };
+    (StrLit($s:expr)) => {
+        Expr::Literal(RuntimeVal::String(String::from($s)))
+    };
+    (Ident($s:expr)) => {
+        Expr::Ident(String::from($s))
+    };
+    (Binary($ln:ident$l:tt, $op:ident, $rn:ident$r:tt)) => {
+        Expr::Binary {
+            left: Box::new(expr!($ln$l)),
+            operation: BinaryOp::$op,
+            right: Box::new(expr!($rn$r)),
+        }
+    };
+    (Unary($op:ident, $rn:ident$r:tt)) => {
+        Expr::Unary {
+            operation: UnaryOp::$op,
+            right: Box::new(expr!($rn$r)),
+        }
+    };
+    (Call($cn:ident$c:tt, [$($an:ident$a:tt),* $(,)?])) => {
+        Expr::Call {
+            callee: Box::new(expr!($cn$c)),
+            args: vec![$(expr!($an$a)),*],
+        }
+    };
+    (Decl($vn:ident$v:tt, $slot:expr)) => {
+        Expr::Decl {
+            value: Box::new(expr!($vn$v)),
+            slot: $slot,
+        }
+    };
+    (VarGet($slot:expr)) => {
+        Expr::VarGet {
+            slot: $slot,
+        }
+    };
+    (Block{$($ln:ident$l:tt),* $(,)?}) => {
+        Expr::Block(vec![$(expr!($ln$l)),*])
+    };
+    (If{$cn:ident$c:tt, $tn:ident$t:tt, None}) => {
+        Expr::If {
+            cond: Box::new(expr!($cn$c)),
+            then: Box::new(expr!($tn$t)),
+            otherwise: None,
+        }
+    };
+    (If{$cn:ident$($c:tt)?, $tn:ident$($t:tt)?, $on:ident$($o:tt)?}) => {
+        Expr::If {
+            cond: Box::new(expr!($cn$($c)?)),
+            then: Box::new(expr!($tn$($t)?)),
+            otherwise: Some(Box::new(expr!($on$($o)?))),
+        }
+    };
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,12 +26,12 @@ pub enum Expr {
     VarGet {
         slot: usize,
     },
+    Block(Vec<Expr>),
     If {
         cond: Box<Expr>,
         then: Box<Expr>,
         otherwise: Option<Box<Expr>>,
     },
-    Block(Vec<Expr>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,10 +55,9 @@ pub struct Parser<I: Iterator<Item = Token>> {
 }
 
 impl<I: Iterator<Item = Token>> Parser<I> {
-    // TODO: change stream to be IntoIter
-    pub fn new(stream: I) -> Self {
+    pub fn new<II: IntoIterator<IntoIter = I>>(stream: II) -> Self {
         Self {
-            stream: stream.peekable(),
+            stream: stream.into_iter().peekable(),
             next_index: 0,
             env: vec![HashMap::new()], // global
         }
@@ -309,382 +308,243 @@ impl<I: Iterator<Item = Token>> Parser<I> {
 
 #[cfg(test)]
 mod tests {
+    use crate::{expr, one_token, tokens};
+
     use super::*;
 
     #[test]
     fn test_num_literal() {
-        let mut parser = Parser::new([Token::NumLit(4.0)].into_iter());
-        assert_eq!(parser.parse_expr(), Expr::Literal(RuntimeVal::Number(4.0)));
+        let mut parser = Parser::new(tokens!(NumLit(4.0)));
+        assert_eq!(parser.parse_expr(), expr!(NumLit(4.0)));
     }
 
     #[test]
     fn test_string_literal() {
-        let mut parser = Parser::new([Token::StringLit("dingus".to_string())].into_iter());
-        assert_eq!(
-            parser.parse_expr(),
-            Expr::Literal(RuntimeVal::String("dingus".to_string()))
-        );
+        let mut parser = Parser::new(tokens!(StrLit("dingus")));
+        assert_eq!(parser.parse_expr(), expr!(StrLit("dingus")));
     }
 
     #[test]
     fn test_parentheses() {
-        let mut parser =
-            Parser::new([Token::OpenParen, Token::NumLit(4.0), Token::CloseParen].into_iter());
-        assert_eq!(parser.parse_expr(), Expr::Literal(RuntimeVal::Number(4.0)));
+        let mut parser = Parser::new(tokens!(OpenParen, NumLit(4.0), CloseParen));
+        assert_eq!(parser.parse_expr(), expr!(NumLit(4.0)));
     }
 
     #[test]
     fn test_add() {
-        let mut parser =
-            Parser::new([Token::NumLit(4.0), Token::Plus, Token::NumLit(5.0)].into_iter());
-        let target = Expr::Binary {
-            left: Box::new(Expr::Literal(RuntimeVal::Number(4.0))),
-            operation: BinaryOp::Add,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(5.0))),
-        };
+        let mut parser = Parser::new(tokens!(NumLit(4.0), Plus, NumLit(5.0)));
+        let target = expr!(Binary(NumLit(4.0), Add, NumLit(5.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_subtract() {
-        let mut parser =
-            Parser::new([Token::NumLit(4.0), Token::Minus, Token::NumLit(5.0)].into_iter());
-        let target = Expr::Binary {
-            left: Box::new(Expr::Literal(RuntimeVal::Number(4.0))),
-            operation: BinaryOp::Subtract,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(5.0))),
-        };
+        let mut parser = Parser::new(tokens!(NumLit(4.0), Minus, NumLit(5.0)));
+        let target = expr!(Binary(NumLit(4.0), Subtract, NumLit(5.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_multiply() {
-        let mut parser =
-            Parser::new([Token::NumLit(20.0), Token::Star, Token::NumLit(22.0)].into_iter());
-        let target = Expr::Binary {
-            left: Box::new(Expr::Literal(RuntimeVal::Number(20.0))),
-            operation: BinaryOp::Multiply,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(22.0))),
-        };
+        let mut parser = Parser::new(tokens!(NumLit(20.0), Star, NumLit(22.0)));
+        let target = expr!(Binary(NumLit(20.0), Multiply, NumLit(22.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_divide() {
-        let mut parser =
-            Parser::new([Token::NumLit(20.0), Token::Slash, Token::NumLit(22.0)].into_iter());
-        let target = Expr::Binary {
-            left: Box::new(Expr::Literal(RuntimeVal::Number(20.0))),
-            operation: BinaryOp::Divide,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(22.0))),
-        };
+        let mut parser = Parser::new(tokens!(NumLit(20.0), Slash, NumLit(22.0)));
+        let target = expr!(Binary(NumLit(20.0), Divide, NumLit(22.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_simple_funcall() {
-        let mut parser = Parser::new(
-            [
-                Token::Ident("my_func".to_string()),
-                Token::OpenParen,
-                Token::CloseParen,
-            ]
-            .into_iter(),
-        );
-
-        let target = Expr::Call {
-            callee: Box::new(Expr::Ident("my_func".to_string())),
-            args: vec![],
-        };
-
+        let mut parser = Parser::new(tokens!(Ident("my_func"), OpenParen, CloseParen));
+        let target = expr!(Call(Ident("my_func"), []));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_complex_funcall() {
-        let mut parser = Parser::new(
-            [
-                Token::Ident("my_func".to_string()),
-                Token::OpenParen,
-                Token::NumLit(42.0),
-                Token::Comma,
-                Token::NumLit(88.0),
-                Token::CloseParen,
-                Token::OpenParen,
-                Token::StringLit("dingus".to_string()),
-                Token::CloseParen,
-            ]
-            .into_iter(),
-        );
-
-        let target = Expr::Call {
-            callee: Box::new(Expr::Call {
-                callee: Box::new(Expr::Ident("my_func".to_string())),
-                args: vec![
-                    Expr::Literal(RuntimeVal::Number(42.0)),
-                    Expr::Literal(RuntimeVal::Number(88.0)),
-                ],
-            }),
-            args: vec![Expr::Literal(RuntimeVal::String("dingus".to_string()))],
-        };
-
+        let mut parser = Parser::new(tokens!(
+            Ident("my_func".to_string()),
+            OpenParen,
+            NumLit(42.0),
+            Comma,
+            NumLit(88.0),
+            CloseParen,
+            OpenParen,
+            StringLit("dingus".to_string()),
+            CloseParen
+        ));
+        let target = expr!(Call(
+            Call(Ident("my_func"), [NumLit(42.0), NumLit(88.0)]),
+            [StrLit("dingus")]
+        ));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_unary_minus() {
-        let mut parser = Parser::new([Token::Minus, Token::NumLit(6.0)].into_iter());
-
-        let target = Expr::Unary {
-            operation: UnaryOp::Negate,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-        };
-
+        let mut parser = Parser::new(tokens!(Minus, NumLit(6.0)));
+        let target = expr!(Unary(Negate, NumLit(6.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_unary_bitnot() {
-        let mut parser = Parser::new([Token::Tilde, Token::NumLit(6.0)].into_iter());
-
-        let target = Expr::Unary {
-            operation: UnaryOp::BitNot,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-        };
-
+        let mut parser = Parser::new(tokens!(Tilde, NumLit(6.0)));
+        let target = expr!(Unary(BitNot, NumLit(6.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_unary_and_minus() {
-        let mut parser = Parser::new(
-            [
-                Token::Minus,
-                Token::NumLit(6.0),
-                Token::Minus,
-                Token::NumLit(6.0),
-            ]
-            .into_iter(),
-        );
-
-        let target = Expr::Binary {
-            left: Box::new(Expr::Unary {
-                operation: UnaryOp::Negate,
-                right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-            }),
-            operation: BinaryOp::Subtract,
-            right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-        };
-
+        let mut parser = Parser::new(tokens!(Minus, NumLit(6.0), Minus, NumLit(6.0)));
+        let target = expr!(Binary(Unary(Negate, NumLit(6.0)), Subtract, NumLit(6.0)));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_unary_with_parens() {
-        let mut parser = Parser::new(
-            [
-                Token::Minus,
-                Token::OpenParen,
-                Token::NumLit(6.0),
-                Token::Plus,
-                Token::NumLit(6.0),
-                Token::CloseParen,
-            ]
-            .into_iter(),
-        );
-
-        let target = Expr::Unary {
-            operation: UnaryOp::Negate,
-            right: Box::new(Expr::Binary {
-                left: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-                operation: BinaryOp::Add,
-                right: Box::new(Expr::Literal(RuntimeVal::Number(6.0))),
-            }),
-        };
-
+        let mut parser = Parser::new(tokens!(
+            Minus,
+            OpenParen,
+            NumLit(6.0),
+            Plus,
+            NumLit(6.0),
+            CloseParen
+        ));
+        let target = expr!(Unary(Negate, Binary(NumLit(6.0), Add, NumLit(6.0))));
         assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_block() {
         // empty
-        let parsed =
-            Parser::new([Token::OpenBracket, Token::CloseBracket, Token::Semi].into_iter())
-                .parse_expr();
-
+        let mut parser = Parser::new(tokens!(OpenBracket, CloseBracket, Semi));
         let target = Expr::Block(vec![]);
-
-        assert_eq!(parsed, target);
+        assert_eq!(parser.parse_expr(), target);
 
         // one, return last
-        let parsed = Parser::new(
-            [
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
-
-        let target = Expr::Block(vec![Expr::Literal(RuntimeVal::Number(4.0))]);
-
-        assert_eq!(parsed, target);
+        let mut parser = Parser::new(tokens!(OpenBracket, NumLit(4.0), CloseBracket, Semi));
+        let target = expr!(Block { NumLit(4.0) });
+        assert_eq!(parser.parse_expr(), target);
 
         // one, don't return last
-        let parsed = Parser::new(
-            [
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::Semi,
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
-
-        let target = Expr::Block(vec![
-            Expr::Literal(RuntimeVal::Number(4.0)),
-            Expr::Literal(RuntimeVal::Null),
-        ]);
-
-        assert_eq!(parsed, target);
+        let mut parser = Parser::new(tokens!(OpenBracket, NumLit(4.0), Semi, CloseBracket, Semi));
+        let target = expr!(Block {
+            NumLit(4.0),
+            Null()
+        });
+        assert_eq!(parser.parse_expr(), target);
 
         // many, return last
-        let parsed = Parser::new(
-            [
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::Semi,
-                Token::NumLit(5.0),
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
-
-        let target = Expr::Block(vec![
-            Expr::Literal(RuntimeVal::Number(4.0)),
-            Expr::Literal(RuntimeVal::Number(5.0)),
-        ]);
-
-        assert_eq!(parsed, target);
+        let mut parser = Parser::new(tokens!(
+            OpenBracket,
+            NumLit(4.0),
+            Semi,
+            NumLit(5.0),
+            CloseBracket,
+            Semi
+        ));
+        let target = expr!(Block {
+            NumLit(4.0),
+            NumLit(5.0)
+        });
+        assert_eq!(parser.parse_expr(), target);
 
         // many, don't return last
-        let parsed = Parser::new(
-            [
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::Semi,
-                Token::NumLit(5.0),
-                Token::Semi,
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
-
-        let target = Expr::Block(vec![
-            Expr::Literal(RuntimeVal::Number(4.0)),
-            Expr::Literal(RuntimeVal::Number(5.0)),
-            Expr::Literal(RuntimeVal::Null),
-        ]);
-
-        assert_eq!(parsed, target);
+        let mut parser = Parser::new(tokens!(
+            OpenBracket,
+            NumLit(4.0),
+            Semi,
+            NumLit(5.0),
+            Semi,
+            CloseBracket,
+            Semi
+        ));
+        let target = expr!(Block {
+            NumLit(4.0),
+            NumLit(5.0),
+            Null()
+        });
+        assert_eq!(parser.parse_expr(), target);
     }
 
     #[test]
     fn test_if() {
         // if
-        let parsed = Parser::new(
-            [
-                Token::If,
-                Token::NumLit(1.0),
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
+        let mut parser = Parser::new(tokens!(
+            If,
+            NumLit(1.0),
+            OpenBracket,
+            NumLit(4.0),
+            CloseBracket,
+            Semi
+        ));
 
-        let target = Expr::If {
-            cond: Box::new(Expr::Literal(RuntimeVal::Number(1.0))),
-            then: Box::new(Expr::Block(vec![Expr::Literal(RuntimeVal::Number(4.0))])),
-            otherwise: None,
-        };
+        let target = expr!(If {
+            NumLit(1.0),
+            Block { NumLit(4.0) },
+            None
+        });
 
-        assert_eq!(parsed, target);
+        assert_eq!(parser.parse_expr(), target);
 
         // if otherwise
-        let parsed = Parser::new(
-            [
-                Token::If,
-                Token::NumLit(1.0),
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::CloseBracket,
-                Token::Otherwise,
-                Token::OpenBracket,
-                Token::NumLit(5.0),
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
+        let mut parser = Parser::new(tokens!(
+            If,
+            NumLit(1.0),
+            OpenBracket,
+            NumLit(4.0),
+            CloseBracket,
+            Otherwise,
+            OpenBracket,
+            NumLit(5.0),
+            CloseBracket,
+            Semi
+        ));
 
-        let target = Expr::If {
-            cond: Box::new(Expr::Literal(RuntimeVal::Number(1.0))),
-            then: Box::new(Expr::Block(vec![Expr::Literal(RuntimeVal::Number(4.0))])),
-            otherwise: Some(Box::new(Expr::Block(vec![Expr::Literal(
-                RuntimeVal::Number(5.0),
-            )]))),
-        };
+        let target = expr!(If {
+            NumLit(1.0),
+            Block { NumLit(4.0) },
+            Block { NumLit(5.0) }
+        });
 
-        assert_eq!(parsed, target);
+        assert_eq!(parser.parse_expr(), target);
 
         // if otherwise-if otherwise
-        let parsed = Parser::new(
-            [
-                Token::If,
-                Token::NumLit(1.0),
-                Token::OpenBracket,
-                Token::NumLit(4.0),
-                Token::CloseBracket,
-                Token::Otherwise,
-                Token::If,
-                Token::NumLit(2.0),
-                Token::OpenBracket,
-                Token::NumLit(5.0),
-                Token::CloseBracket,
-                Token::Otherwise,
-                Token::OpenBracket,
-                Token::NumLit(6.0),
-                Token::CloseBracket,
-                Token::Semi,
-            ]
-            .into_iter(),
-        )
-        .parse_expr();
+        let mut parser = Parser::new(tokens!(
+            If,
+            NumLit(1.0),
+            OpenBracket,
+            NumLit(4.0),
+            CloseBracket,
+            Otherwise,
+            If,
+            NumLit(2.0),
+            OpenBracket,
+            NumLit(5.0),
+            CloseBracket,
+            Otherwise,
+            OpenBracket,
+            NumLit(6.0),
+            CloseBracket,
+            Semi
+        ));
 
-        let target = Expr::If {
-            cond: Box::new(Expr::Literal(RuntimeVal::Number(1.0))),
-            then: Box::new(Expr::Block(vec![Expr::Literal(RuntimeVal::Number(4.0))])),
-            otherwise: Some(Box::new(Expr::If {
-                cond: Box::new(Expr::Literal(RuntimeVal::Number(2.0))),
-                then: Box::new(Expr::Block(vec![Expr::Literal(RuntimeVal::Number(5.0))])),
-                otherwise: Some(Box::new(Expr::Block(vec![Expr::Literal(
-                    RuntimeVal::Number(6.0),
-                )]))),
-            })),
-        };
+        let target = expr!(If {
+            NumLit(1.0),
+            Block { NumLit(4.0) },
+            If {
+                NumLit(2.0),
+                Block { NumLit(5.0) },
+                Block { NumLit(6.0) }
+            }
+        });
 
-        assert_eq!(parsed, target);
+        assert_eq!(parser.parse_expr(), target);
     }
 }


### PR DESCRIPTION
## Macros
* Created the `macros.rs` module to hold macros usable by Ferric.

### `one_token!`
* Handles one token, with the `StrLit` branch creating a `Token::StringLit` and the `Ident` branch creating a `Token::Ident`.
* The final branch will prepend the input with `Token::`.

### `tokens!`
* Calls `one_token!` on all of the tokens passed in.
* Formatted into an array literal.

### `expr!`
* Recursive macro to expand into `Expr` literals.
* Each node must be followed by parenthesis (even `Expr::Null`) with the arguments for that node.
* Call arguments are wrapped with `[]`.
* Block contents are wrapped with `{}` to simulate an actual block.
* If contents are wrapped with `{}`.

## Misc
* Combined `impl` blocks in `lexer.rs`.
* Reordered `Expr` declaration to match parse order.
* Changed the `Parser::new` function to accept anything that can be turned into an iterator.