### PR TITLE
Add substr() and len() builtin functions

### DIFF
--- a/ferric/src/interpreter.rs
+++ b/ferric/src/interpreter.rs
@@ -345,7 +345,7 @@ fn builtin_len<W: Write>(i: &mut Interpreter<'_, W>, args: Vec<RuntimeVal>) -> R
     );
     match &args[0] {
         RuntimeVal::String(string) => RuntimeVal::Number(string.len() as f64),
-        _ => panic!("len: Object {} has no length property", &args[0]),
+        _ => panic!("len(): Object {} has no length property", &args[0]),
     }
 }
 


### PR DESCRIPTION
This PR adds the `substr` and `len` builtin functions, working towards #48 

# substr
The `substr()` builtin function takes a string as its first argument, and two indices as its second. The indices must be integer-like (no fractional component) and the string must be made up only of ASCII bytes. It returns a string runtimeval containing the characters starting at the first (inclusive) and up to the last (exclusive). If any more or less arguments are 

# len
The `len()` builtin function takes a string as its only argument, and returns the byte length of that string. It is intended to eventually also be able to take lengths of other collection types when they are added to the language.