### PR TITLE
Implement the parsing of function definitions.

### DIFF
--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -749,4 +749,26 @@ mod tests {
 
         assert_eq!(parser.parse_expr().unwrap(), target);
     }
+
+    //    #[test]
+    //    pub fn function_definition() {
+    //	let mut parser = Parser::new(tokens![
+    //	    Fn,
+    //	    OpenParen,
+    //	    Ident("param1".to_string()),
+    //	    Comma,
+    //	    Ident("Param2".to_string()),
+    //	    CloseParen,
+    //	    OpenBracket,
+    //	    NumLit(42.0),
+    //	    CloseBracket,
+    //	]);
+    //	let target = expr!(Func {
+    //	    [Ident("param1"), Ident("param2")],
+    //	    Block {
+    //		NumLit(42.0),
+    //	    }
+    //	});
+    //	assert_eq!(parser.parse(), target);
+    //    }
 }

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -57,7 +57,7 @@ pub enum Expr {
     Func {
         params: Vec<String>,
         body: Vec<Expr>,
-    }
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -146,6 +146,23 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
             panic!("{message}");
         };
         Ok(name)
+    }
+
+    // consume_parameters assumes that the initial opening paren has
+    // already been parsed.
+    fn consume_parameters(&mut self) -> Res<Vec<String>> {
+        let mut parameters: Vec<String> = Vec::new();
+        if !self.matches(Token::CloseParen)? {
+            parameters.push(self.consume_ident("Function parameters may only be idents")?);
+            while self.matches(Token::Comma)? {
+                parameters.push(self.consume_ident("Function parameters may only be idents")?);
+            }
+            self.consume(
+                Token::CloseParen,
+                "Unclosed function definition parentheses or missing comma.",
+            )?;
+        }
+        Ok(parameters)
     }
 
     pub fn parse(&mut self) -> Res<(Vec<Expr>, usize)> {
@@ -317,6 +334,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 .map(|slot| Expr::VarGet { slot })
                 .unwrap_or(Expr::Ident(identifier)),
             Token::Let => self.parse_decl()?,
+            Token::Fn => self.parse_func_def()?,
             Token::If => self.parse_if()?,
             Token::OpenBracket => self.parse_block()?,
             Token::While => self.parse_while()?,
@@ -348,6 +366,18 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         };
         self.next_index += 1;
         Ok(expr)
+    }
+
+    fn parse_func_def(&mut self) -> Res<Expr> {
+        self.consume(
+            Token::OpenParen,
+            "Function definition requires an opening parentheses.",
+        )?;
+        let params = self.consume_parameters()?;
+        Ok(Expr::Func {
+            params,
+            body: vec![self.parse_block()?],
+        })
     }
 
     fn parse_if(&mut self) -> Res<Expr> {


### PR DESCRIPTION
This PR Implements the parsing of function definitions.

# New
## Parser
### consume_parameters
The new function `consume_parameters()` parses a function's parameter list into a `Vec` of `String`s. Like `consume_args()`, it expects that the opening parentheses has already been consumed.

### parse_func_def
The new function `parse_func_def()` parses a function definition into is parameters list and a block expression.

# Tests
- New test `function_definitions()` has been mostly implemented, but requires a new macro arm.