### PR TITLE
Refactor of Variable Storage for Interpreter

### DIFF
--- a/ferric/src/interpreter.rs
+++ b/ferric/src/interpreter.rs
@@ -27,7 +27,7 @@ enum Function {
     Custom {
         param_count: usize,
         body: Rc<Expr>,
-        closure: Environment
+        closure: Environment,
     },
 }
 
@@ -91,10 +91,10 @@ impl Environment {
 
     fn get(&self, depth: usize, slot: usize) -> RuntimeVal {
         let desc = self.decendent(depth);
-        let frame = desc
-            .0
-            .borrow();
-        frame.vars.get(slot)
+        let frame = desc.0.borrow();
+        frame
+            .vars
+            .get(slot)
             .unwrap_or_else(|| panic!("depth: {depth}, slot: {slot}"))
             .clone()
     }
@@ -258,7 +258,11 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 "sleep" => builtin_sleep(self, args),
                 x => panic!("Function {} was not found", x),
             },
-            RuntimeVal::Function(Function::Custom { param_count, body, closure }) => {
+            RuntimeVal::Function(Function::Custom {
+                param_count,
+                body,
+                closure,
+            }) => {
                 assert!(param_count == args.len());
                 let func_env = Environment::new(closure);
 
@@ -268,27 +272,27 @@ impl<'a, W: Write> Interpreter<'a, W> {
 
                 match body.as_ref() {
                     Expr::Block(b) => self.evaluate_block(b, func_env)?,
-                    _ => unreachable!("did not find body")
+                    _ => unreachable!("did not find body"),
                 }
-                
-
             }
             _ => panic!("Invalid function call"),
         })
     }
 
-    fn evaluate_block(&mut self, expressions: &Vec<Expr>, new_env: Environment) -> Result<RuntimeVal, RuntimeError> {
+    fn evaluate_block(
+        &mut self,
+        expressions: &Vec<Expr>,
+        new_env: Environment,
+    ) -> Result<RuntimeVal, RuntimeError> {
         let old_env = self.env.clone();
         self.env = new_env;
         // returns Null on empty block
         let mut last_val = RuntimeVal::Null;
         for exp in expressions {
             last_val = self.evaluate(&exp)?;
-
         }
         self.env = old_env;
         Result::Ok(last_val)
-
     }
 
     // evalute -> condense tree -> runTimeVal
@@ -343,20 +347,19 @@ impl<'a, W: Write> Interpreter<'a, W> {
 
                 RuntimeVal::Null
             }
-            Expr::VarGet { depth, slot  } => self.env.get(*depth, *slot),
+            Expr::VarGet { depth, slot } => self.env.get(*depth, *slot),
             Expr::VarSet { depth, slot, value } => {
                 let val = self.evaluate(value)?;
                 self.env.set(*depth, *slot, val);
                 RuntimeVal::Null
-            },
+            }
             Expr::Func { param_count, body } => {
-             
                 RuntimeVal::Function(Function::Custom {
                     param_count: *param_count,
                     body: body.to_owned().into(), // body.to_owned().into(),
-                    closure: self.env.clone()
+                    closure: self.env.clone(),
                 })
-            },
+            }
             Expr::If {
                 cond,
                 then,
@@ -379,7 +382,8 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 }
             }
             Expr::Block(expressions) => {
-                let last_val = self.evaluate_block(expressions,Environment::new(self.env.clone()))?;
+                let last_val =
+                    self.evaluate_block(expressions, Environment::new(self.env.clone()))?;
                 last_val
             }
             Expr::While { cond, body } => {

--- a/ferric/src/interpreter.rs
+++ b/ferric/src/interpreter.rs
@@ -25,8 +25,9 @@ type Res<T> = Result<T, RuntimeError>;
 enum Function {
     BuiltIn(String),
     Custom {
-        args: Rc<[String]>,
-        body: Rc<[Expr]>,
+        param_count: usize,
+        body: Rc<Expr>,
+        closure: Environment
     },
 }
 
@@ -51,13 +52,13 @@ impl Display for RuntimeVal {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct EnvLevel {
     parent: Option<Rc<RefCell<EnvLevel>>>,
     vars: Vec<RuntimeVal>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct Environment(Rc<RefCell<EnvLevel>>);
 
 impl Environment {
@@ -233,7 +234,7 @@ fn operation_leq(left: RuntimeVal, right: RuntimeVal) -> Res<RuntimeVal> {
 
 pub struct Interpreter<'a, W: Write> {
     output: &'a mut W,
-    var_storage: Vec<RuntimeVal>,
+    env: Environment,
     start_time: DateTime<Utc>,
 }
 
@@ -241,7 +242,7 @@ impl<'a, W: Write> Interpreter<'a, W> {
     pub fn new(output: &'a mut W) -> Self {
         Self {
             output,
-            var_storage: vec![RuntimeVal::Null; todo!()],
+            env: Environment::new_global(),
             start_time: Utc::now(),
         }
     }
@@ -257,15 +258,37 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 "sleep" => builtin_sleep(self, args),
                 x => panic!("Function {} was not found", x),
             },
-            RuntimeVal::Function(Function::Custom { args, body }) => {
-                let mut res = RuntimeVal::Null;
-                for expr in body.iter() {
-                    res = self.evaluate(expr).expect("Unable to fetch function body"); // TODO: as of 4/13/26, this is just a single block
+            RuntimeVal::Function(Function::Custom { param_count, body, closure }) => {
+                assert!(param_count == args.len());
+                let func_env = Environment::new(closure);
+
+                for arg in args {
+                    func_env.declare(arg);
                 }
-                res
+
+                match body.as_ref() {
+                    Expr::Block(b) => self.evaluate_block(b, func_env)?,
+                    _ => unreachable!("did not find body")
+                }
+                
+
             }
             _ => panic!("Invalid function call"),
         })
+    }
+
+    fn evaluate_block(&mut self, expressions: &Vec<Expr>, new_env: Environment) -> Result<RuntimeVal, RuntimeError> {
+        let old_env = self.env.clone();
+        self.env = new_env;
+        // returns Null on empty block
+        let mut last_val = RuntimeVal::Null;
+        for exp in expressions {
+            last_val = self.evaluate(&exp)?;
+
+        }
+        self.env = old_env;
+        Result::Ok(last_val)
+
     }
 
     // evalute -> condense tree -> runTimeVal
@@ -315,26 +338,25 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 RuntimeVal::Function(Function::BuiltIn(name.clone()))
             }
             Expr::Decl { value } => {
-                
-                let slot: &usize = todo!();
-                
                 let val = self.evaluate(value)?;
-                let var = self
-                    .var_storage
-                    .get_mut(*slot)
-                    .expect("Unable to fetch variable");
-                *var = val;
+                self.env.declare(val);
+
                 RuntimeVal::Null
             }
-            Expr::VarGet { depth, slot  } => self.var_storage[*slot].clone(),
+            Expr::VarGet { depth, slot  } => self.env.get(*depth, *slot),
             Expr::VarSet { depth, slot, value } => {
-                self.var_storage[*slot] = self.evaluate(value)?;
+                let val = self.evaluate(value)?;
+                self.env.set(*depth, *slot, val);
                 RuntimeVal::Null
-            }
-            Expr::Func { param_count, body } => RuntimeVal::Function(Function::Custom {
-                args: todo!(), // params.to_owned().into(),
-                body: todo!(), // body.to_owned().into(),
-            }),
+            },
+            Expr::Func { param_count, body } => {
+             
+                RuntimeVal::Function(Function::Custom {
+                    param_count: *param_count,
+                    body: body.to_owned().into(), // body.to_owned().into(),
+                    closure: self.env.clone()
+                })
+            },
             Expr::If {
                 cond,
                 then,
@@ -357,11 +379,7 @@ impl<'a, W: Write> Interpreter<'a, W> {
                 }
             }
             Expr::Block(expressions) => {
-                // returns Null on empty block
-                let mut last_val = RuntimeVal::Null;
-                for exp in expressions {
-                    last_val = self.evaluate(exp)?;
-                }
+                let last_val = self.evaluate_block(expressions,Environment::new(self.env.clone()))?;
                 last_val
             }
             Expr::While { cond, body } => {

--- a/ferric/src/lib.rs
+++ b/ferric/src/lib.rs
@@ -29,9 +29,7 @@ mod tests {
 
         let mut output = vec![];
 
-        Interpreter::new(&mut output)
-            .interpret(&expr)
-            .unwrap();
+        Interpreter::new(&mut output).interpret(&expr).unwrap();
 
         String::from_utf8(output).expect("Program outputted invalid utf8")
     }

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -193,7 +193,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
             return Ok(Expr::VarSet {
                 value: Box::new(right),
                 slot,
-                depth: todo!()
+                depth: todo!(),
             });
         }
         Ok(left)
@@ -340,7 +340,10 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
             Token::False => Expr::Literal(RuntimeVal::Boolean(false)),
             Token::Ident(identifier) => self
                 .find_var(&identifier)
-                .map(|slot| Expr::VarGet { slot, depth: todo!() })
+                .map(|slot| Expr::VarGet {
+                    slot,
+                    depth: todo!(),
+                })
                 .unwrap_or(Expr::Ident(identifier)),
             Token::Let => self.parse_decl()?,
             Token::Fn => self.parse_func_def()?,
@@ -387,7 +390,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         )?;
         Ok(Expr::Func {
             param_count: todo!(),
-            body: todo!() // vec![self.parse_block()?],
+            body: todo!(), // vec![self.parse_block()?],
         })
     }
 


### PR DESCRIPTION
# Major
- `Custom` in enum `Function` holds number of parameters, a body (single expression), and the environment where the function is declared
- `var_storage` is now single `Environment`
- `Function` now checks for environment variables at start of environment, assigns all variables to the current environment, and returns the last value in the block.
- declarations, gets, and sets, now use current environment (`env`)

## Minor
- add `PartialEq` on `EnvLevel` and `Environment`