### PR TITLE
Implement a type inferencer.

### DIFF
--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -205,9 +205,7 @@ fn type_of_binaryop(typ_left: &Typ, kind: &BinaryOp, typ_right: &Typ) -> Typ {
         BinaryOp::Add => match (typ_left, typ_right) {
             (Typ::Number, Typ::Number) => Typ::Number,
             (Typ::String, Typ::String) => Typ::String,
-            _ => panic!(
-                "Unsupported types for addition: left: {typ_left:?}, right: {typ_right:?}"
-            ),
+            _ => panic!("Unsupported types for addition: left: {typ_left:?}, right: {typ_right:?}"),
         },
         BinaryOp::Subtract => match (typ_left, typ_right) {
             (Typ::Number, Typ::Number) => Typ::Number,
@@ -224,15 +222,11 @@ fn type_of_binaryop(typ_left: &Typ, kind: &BinaryOp, typ_right: &Typ) -> Typ {
         },
         BinaryOp::Divide => match (typ_left, typ_right) {
             (Typ::Number, Typ::Number) => Typ::Number,
-            _ => panic!(
-                "Unsupported types for division: left: {typ_left:?}, right: {typ_right:?}"
-            ),
+            _ => panic!("Unsupported types for division: left: {typ_left:?}, right: {typ_right:?}"),
         },
         BinaryOp::Modulo => match (typ_left, typ_right) {
             (Typ::Number, Typ::Number) => Typ::Number,
-            _ => panic!(
-                "Unsupported types for modulo: left {typ_left:?}, right: {typ_right:?}"
-            ),
+            _ => panic!("Unsupported types for modulo: left {typ_left:?}, right: {typ_right:?}"),
         },
         BinaryOp::Equal
         | BinaryOp::NotEqual
@@ -241,15 +235,40 @@ fn type_of_binaryop(typ_left: &Typ, kind: &BinaryOp, typ_right: &Typ) -> Typ {
         | BinaryOp::GreaterEq
         | BinaryOp::LessEq => match (typ_left, typ_right) {
             (Typ::Number, Typ::Number) | (Typ::String, Typ::String) => Typ::Unknown,
-            _ => panic!(
-                "Unsupported types for comparison: left: {typ_left:?}, right: {typ_right:?}"
-            ),
+            _ => {
+                panic!("Unsupported types for comparison: left: {typ_left:?}, right: {typ_right:?}")
+            }
         },
     }
 }
 
+// TODO: This is a terrible implementation of function name resolution. We'd likely do better
+// with a hash table based implementation, but more discussion is needed on the arcitecture
+// of such a solution.
 fn type_of_ident(string: &String) -> Typ {
-    todo!();
+    match string.as_str() {
+        "print" => Typ::Function {
+            vars: Vec::new(),
+            ret: Box::new(Typ::Null),
+        },
+        "substr" => Typ::Function {
+            vars: Vec::new(),
+            ret: Box::new(Typ::String),
+        },
+        "len" => Typ::Function {
+            vars: Vec::new(),
+            ret: Box::new(Typ::Number),
+        },
+        "clock" => Typ::Function {
+            vars: Vec::new(),
+            ret: Box::new(Typ::Number),
+        },
+        "unix_time" => Typ::Function {
+            vars: Vec::new(),
+            ret: Box::new(Typ::Number),
+        },
+        _ => panic!("Got ident which does not resolve to function: {string}"),
+    }
 }
 
 impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
@@ -369,8 +388,11 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 RuntimeVal::Function(_) => unreachable!("Function found in literal expr"),
             },
             ExprKind::VarGet { depth, slot } => {
-                    assert!(*depth < self.env.len(), "Variable get references greater depth than stack size");
-                    assert!(*slot < self.env[*depth].typs.len(), "Variable get references greater slot number than exists in referenced stack frame");
+                assert!(
+                    *depth < self.env.len(),
+                    "Variable get references greater depth than stack size"
+                );
+                assert!(*slot < self.env[*depth].typs.len(), "Variable get references greater slot number than exists in referenced stack frame");
                 self.env[*depth].typs[*slot].clone()
             }
             ExprKind::Unary {

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -187,6 +187,71 @@ impl EnvStackFrame {
     }
 }
 
+fn type_of_unaryop(kind: &UnaryOp, typ_right: &Typ) -> Typ {
+    match kind {
+        UnaryOp::Negate | UnaryOp::BitNot if *typ_right == Typ::Number => Typ::Number,
+        UnaryOp::Negate => panic!("Unsupported type for numeric negation: {typ_right:?}"),
+        UnaryOp::BitNot => panic!("Unsupported type for bitwise not: {typ_right:?}"),
+        UnaryOp::BoolNot if *typ_right == Typ::Unknown => Typ::Unknown,
+        UnaryOp::BoolNot => panic!("Unsupported type for boolean negation: {typ_right:?}"),
+    }
+}
+
+fn type_of_binaryop(typ_left: &Typ, kind: &BinaryOp, typ_right: &Typ) -> Typ {
+    if *typ_left == Typ::Any || *typ_right == Typ::Any {
+        return Typ::Any;
+    }
+    match kind {
+        BinaryOp::Add => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) => Typ::Number,
+            (Typ::String, Typ::String) => Typ::String,
+            _ => panic!(
+                "Unsupported types for addition: left: {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+        BinaryOp::Subtract => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) => Typ::Number,
+            _ => panic!(
+                "Unsupported types for subtraction: left: {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+        BinaryOp::Multiply => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) => Typ::Number,
+            (Typ::String, Typ::Number) => Typ::String,
+            _ => panic!(
+                "Unsupported types for multiplication: left {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+        BinaryOp::Divide => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) => Typ::Number,
+            _ => panic!(
+                "Unsupported types for division: left: {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+        BinaryOp::Modulo => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) => Typ::Number,
+            _ => panic!(
+                "Unsupported types for modulo: left {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+        BinaryOp::Equal
+        | BinaryOp::NotEqual
+        | BinaryOp::GreaterThan
+        | BinaryOp::LessThan
+        | BinaryOp::GreaterEq
+        | BinaryOp::LessEq => match (typ_left, typ_right) {
+            (Typ::Number, Typ::Number) | (Typ::String, Typ::String) => Typ::Unknown,
+            _ => panic!(
+                "Unsupported types for comparison: left: {typ_left:?}, right: {typ_right:?}"
+            ),
+        },
+    }
+}
+
+fn type_of_ident(string: &String) -> Typ {
+    todo!();
+}
+
 impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
     pub fn new<II: IntoIterator<IntoIter = I>>(stream: II, src: ProgramSrc) -> Self {
         Self {
@@ -288,7 +353,70 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
     }
 
     fn type_of(&self, expr: &Expr) -> Typ {
-        todo!();
+        match &expr.kind {
+            ExprKind::VarSet {
+                value: _,
+                depth: _,
+                slot: _,
+            }
+            | ExprKind::Decl { value: _ }
+            | ExprKind::While { cond: _, body: _ } => Typ::Null,
+            ExprKind::Literal(kind) => match kind {
+                RuntimeVal::Number(_) => Typ::Number,
+                RuntimeVal::String(_) => Typ::String,
+                RuntimeVal::Boolean(_) => Typ::Unknown,
+                RuntimeVal::Null => Typ::Null,
+                RuntimeVal::Function(_) => unreachable!("Function found in literal expr"),
+            },
+            ExprKind::VarGet { depth, slot } => {
+                    assert!(*depth < self.env.len(), "Variable get references greater depth than stack size");
+                    assert!(*slot < self.env[*depth].typs.len(), "Variable get references greater slot number than exists in referenced stack frame");
+                self.env[*depth].typs[*slot].clone()
+            }
+            ExprKind::Unary {
+                operation: kind,
+                right,
+            } => type_of_unaryop(kind, &self.type_of(right.as_ref())),
+            ExprKind::Binary {
+                left,
+                operation: kind,
+                right,
+            } => type_of_binaryop(
+                &self.type_of(left.as_ref()),
+                kind,
+                &self.type_of(right.as_ref()),
+            ),
+            ExprKind::Call { callee, args: _ } => match self.type_of(callee) {
+                Typ::Function { vars: _, ret } => *ret,
+                _ => panic!("Attempted to call non-function expr"),
+            },
+            ExprKind::Block(exprs) => self.type_of(exprs.last().unwrap()),
+            ExprKind::Func {
+                param_count: _,
+                body,
+            } => self.type_of(body.last().unwrap()),
+            ExprKind::If {
+                cond,
+                then,
+                otherwise,
+            } => {
+                assert_eq!(
+                    Typ::Unknown,
+                    self.type_of(cond.as_ref()),
+                    "If condition is not of boolean type"
+                );
+                let typ_then = self.type_of(then.last().unwrap());
+                if let Some(other) = otherwise {
+                    let typ_otherwise = self.type_of(other.as_ref());
+                    assert_eq!(
+                        typ_then, typ_otherwise,
+                        "All arms of an if-otherwise chain must evaluate to the same type"
+                    );
+                }
+                typ_then
+            }
+            ExprKind::Ident(string) => type_of_ident(string),
+        }
     }
 
     pub fn parse(&mut self) -> Res<Vec<Expr>> {

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -188,6 +188,9 @@ impl EnvStackFrame {
 }
 
 fn type_of_unaryop(kind: &UnaryOp, typ_right: &Typ) -> Typ {
+    if *typ_right == Typ::Any {
+        return Typ::Any;
+    }
     match kind {
         UnaryOp::Negate | UnaryOp::BitNot if *typ_right == Typ::Number => Typ::Number,
         UnaryOp::Negate => panic!("Unsupported type for numeric negation: {typ_right:?}"),

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -416,7 +416,10 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
             ExprKind::Func {
                 param_count: _,
                 body,
-            } => self.type_of(body.last().unwrap()),
+            } => Typ::Function {
+                vars: Vec::new(),
+                ret: Box::new(self.type_of(body.last().unwrap())),
+            },
             ExprKind::If {
                 cond,
                 then,
@@ -678,7 +681,12 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         self.consume(Token::Eq, "Expected '=' after let")?;
         let init = self.parse_expr()?;
         self.env.last_mut().expect("no global env").insert(name);
+        self.env.last_mut().expect("no global env").typs.push(typ.clone().unwrap().unwrap());
 
+        if let Some(typ_inside) = typ.unwrap() {
+            assert_eq!(typ_inside, self.type_of(&init));
+        }
+        
         let span = let_span + init.span;
 
         let kind = ExprKind::Decl {
@@ -1117,25 +1125,25 @@ mod tests {
         assert_eq!(parser.parse_expr().unwrap(), target);
     }
 
-    //    #[test]
-    //    pub fn function_definition() {
-    //	let mut parser = Parser::test(tokens![
-    //	    Fn,
-    //	    OpenParen,
-    //	    Ident("param1".to_string()),
-    //	    Comma,
-    //	    Ident("Param2".to_string()),
-    //	    CloseParen,
-    //	    OpenBracket,
-    //	    NumLit(42.0),
-    //	    CloseBracket,
-    //	]);
-    //	let target = expr!(Func {
-    //	    [Ident("param1"), Ident("param2")],
-    //	    Block {
-    //		NumLit(42.0),
-    //	    }
-    //	});
-    //	assert_eq!(parser.parse(), target);
-    //    }
+    // #[test]
+    // pub fn function_definition() {
+    //     let mut parser = Parser::test(tokens![
+    //         Fn,
+    //         OpenParen,
+    //         Ident("param1".to_string()),
+    //         Comma,
+    //         Ident("Param2".to_string()),
+    //         CloseParen,
+    //         OpenBracket,
+    //         NumLit(42.0),
+    //         CloseBracket,
+    //     ]);
+    //     let target = expr!(Func {
+    //         [Ident("param1"), Ident("param2")],
+    //         Block {
+    //     	NumLit(42.0),
+    //         }
+    //     });
+    //     assert_eq!(parser.parse(), target);
+    // }
 }

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -409,16 +409,17 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 &self.type_of(right.as_ref()),
             ),
             ExprKind::Call { callee, args: _ } => match self.type_of(callee) {
+                Typ::Any => Typ::Any,
                 Typ::Function { vars: _, ret } => *ret,
                 _ => panic!("Attempted to call non-function expr"),
             },
-            ExprKind::Block(exprs) => self.type_of(exprs.last().unwrap()),
+            ExprKind::Block(exprs) => self.type_of(exprs.last().expect("Block is entirely empty")),
             ExprKind::Func {
                 param_count: _,
                 body,
             } => Typ::Function {
                 vars: Vec::new(),
-                ret: Box::new(self.type_of(body.last().unwrap())),
+                ret: Box::new(self.type_of(body.last().expect("Function body is entirely empty"))),
             },
             ExprKind::If {
                 cond,
@@ -430,7 +431,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                     self.type_of(cond.as_ref()),
                     "If condition is not of boolean type"
                 );
-                let typ_then = self.type_of(then.last().unwrap());
+                let typ_then = self.type_of(then.last().expect("If body is entirely empty"));
                 if let Some(other) = otherwise {
                     let typ_otherwise = self.type_of(other.as_ref());
                     assert_eq!(
@@ -681,11 +682,6 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         self.consume(Token::Eq, "Expected '=' after let")?;
         let init = self.parse_expr()?;
         self.env.last_mut().expect("no global env").insert(name);
-        self.env.last_mut().expect("no global env").typs.push(typ.clone().unwrap().unwrap());
-
-        if let Some(typ_inside) = typ.unwrap() {
-            assert_eq!(typ_inside, self.type_of(&init));
-        }
         
         let span = let_span + init.span;
 


### PR DESCRIPTION
This PR implements a basic type inferencer for ASTs. It also implements extremely rudimentary function name resolution.

# New
## Parser
### type_of
The new method of parser, `self.type_of`, implements the type inferencing of abstract syntax trees. It is a large recursive function which acts like the interpreter, but does not do any actual evaluation. It only attempts to predict the type that an `expr` will evaluate to. If any expression in the tree has type `any`, the whole expression will likely evaluate also to type `any`.

### type_of helpers
There are three helper functions, `type_of_unaryop`, `type_of_binaryop`, and `type_of_ident`. They predict the types for their specific kind of operator (or idents). `type_of_ident` implements the rudimentary function name resolution mentioned as a match statement for the builtin functions. This should certainly be changed in the future, but works for now.

# Changed
Not much, actually. Other work must be done, and I believe is being done separate of this pull request, to actually integrate type checking into the rest of the language.