### PR TITLE
Change type checker to check everything in a block

### DIFF
--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -374,6 +374,13 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         Ok(parameters)
     }
 
+    fn check_block(&self, exprs: &[Expr]) -> Typ {
+	for expr in &exprs[..exprs.len() - 1] {
+	    self.type_of(expr);
+	}
+	self.type_of(exprs.last().expect("check_block received entirely empty block"))
+    }
+    
     fn type_of(&self, expr: &Expr) -> Typ {
         match &expr.kind {
             ExprKind::VarSet {
@@ -381,8 +388,16 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 depth: _,
                 slot: _,
             }
-            | ExprKind::Decl { value: _ }
-            | ExprKind::While { cond: _, body: _ } => Typ::Null,
+            | ExprKind::Decl { value: _ } => Typ::Null,
+	    ExprKind::While { cond, body } => {
+		assert_eq!(
+		    self.type_of(cond),
+		    Typ::Unknown,
+		    "While conditions must be of boolean type",
+		);
+		self.check_block(body);
+		Typ::Null
+	    },
             ExprKind::Literal(kind) => match kind {
                 RuntimeVal::Number(_) => Typ::Number,
                 RuntimeVal::String(_) => Typ::String,
@@ -416,7 +431,12 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 Typ::Function { vars: _, ret } => *ret,
                 _ => panic!("Attempted to call non-function expr"),
             },
-            ExprKind::Block(exprs) => self.type_of(exprs.last().expect("Block is entirely empty")),
+            ExprKind::Block(exprs) => {
+		for expr in &exprs[..exprs.len() - 1] {
+		    self.type_of(expr);
+		}
+		self.type_of(exprs.last().expect("Block is entirely empty"))
+	    },
             ExprKind::Func {
                 param_count: _,
                 body,
@@ -434,7 +454,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                     self.type_of(cond.as_ref()),
                     "If condition is not of boolean type"
                 );
-                let typ_then = self.type_of(then.last().expect("If body is entirely empty"));
+                let typ_then = self.check_block(then);
                 if let Some(other) = otherwise {
                     let typ_otherwise = self.type_of(other.as_ref());
                     assert_eq!(

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -375,12 +375,16 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
     }
 
     fn check_block(&self, exprs: &[Expr]) -> Typ {
-	for expr in &exprs[..exprs.len() - 1] {
-	    self.type_of(expr);
-	}
-	self.type_of(exprs.last().expect("check_block received entirely empty block"))
+        for expr in &exprs[..exprs.len() - 1] {
+            self.type_of(expr);
+        }
+        self.type_of(
+            exprs
+                .last()
+                .expect("check_block received entirely empty block"),
+        )
     }
-    
+
     fn type_of(&self, expr: &Expr) -> Typ {
         match &expr.kind {
             ExprKind::VarSet {
@@ -389,15 +393,15 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 slot: _,
             }
             | ExprKind::Decl { value: _ } => Typ::Null,
-	    ExprKind::While { cond, body } => {
-		assert_eq!(
-		    self.type_of(cond),
-		    Typ::Unknown,
-		    "While conditions must be of boolean type",
-		);
-		self.check_block(body);
-		Typ::Null
-	    },
+            ExprKind::While { cond, body } => {
+                assert_eq!(
+                    self.type_of(cond),
+                    Typ::Unknown,
+                    "While conditions must be of boolean type",
+                );
+                self.check_block(body);
+                Typ::Null
+            }
             ExprKind::Literal(kind) => match kind {
                 RuntimeVal::Number(_) => Typ::Number,
                 RuntimeVal::String(_) => Typ::String,
@@ -432,11 +436,11 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 _ => panic!("Attempted to call non-function expr"),
             },
             ExprKind::Block(exprs) => {
-		for expr in &exprs[..exprs.len() - 1] {
-		    self.type_of(expr);
-		}
-		self.type_of(exprs.last().expect("Block is entirely empty"))
-	    },
+                for expr in &exprs[..exprs.len() - 1] {
+                    self.type_of(expr);
+                }
+                self.type_of(exprs.last().expect("Block is entirely empty"))
+            }
             ExprKind::Func {
                 param_count: _,
                 body,
@@ -705,7 +709,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
         self.consume(Token::Eq, "Expected '=' after let")?;
         let init = self.parse_expr()?;
         self.env.last_mut().expect("no global env").insert(name);
-        
+
         let span = let_span + init.span;
 
         let kind = ExprKind::Decl {


### PR DESCRIPTION
PR name is what it says on the tin. There is a new `check_block` helper of varget which type checks an entire block and returns the type of the block. The `type_of` method has been updated to use it so that all expressions are type checked. The `check_block` method will need to be updated when the improved errors are brought to it.