### PR TITLE
Parser: Desugar for loops into while loops

### DIFF
--- a/executable/src.fe
+++ b/executable/src.fe
@@ -1,1 +1,3 @@
-let x: any = {};
+for let i = 0; i < 10; i = i + 1 {
+    print(i);
+};

--- a/ferric/src/lexer.rs
+++ b/ferric/src/lexer.rs
@@ -1,4 +1,10 @@
-use std::{collections::{HashMap, HashSet}, iter::Peekable, rc::Rc, string::FromUtf8Error, vec};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::Peekable,
+    rc::Rc,
+    string::FromUtf8Error,
+    vec,
+};
 
 use thiserror::Error;
 
@@ -37,6 +43,7 @@ pub enum Token {
     If,           // if
     Otherwise,    // otherwise
     While,        // while
+    For,          // for
     Fn,           // fn
     OpenParen,    // (
     CloseParen,   // )
@@ -92,6 +99,7 @@ impl std::fmt::Display for Token {
             Token::If => write!(f, "if"),
             Token::Otherwise => write!(f, "otherwise"),
             Token::While => write!(f, "while"),
+            Token::For => write!(f, "for"),
             Token::Fn => write!(f, "fn"),
             Token::OpenParen => write!(f, "("),
             Token::CloseParen => write!(f, ")"),
@@ -130,7 +138,6 @@ impl std::fmt::Display for Token {
     }
 }
 
-
 pub struct Lexer<I: Iterator<Item = u8>> {
     stream: Peekable<I>,
     keywords: HashMap<&'static str, Token>,
@@ -149,6 +156,7 @@ impl<I: Iterator<Item = u8>> Lexer<I> {
             ("if", Token::If),
             ("otherwise", Token::Otherwise),
             ("while", Token::While),
+            ("for", Token::For),
             ("fn", Token::Fn),
             ("and", Token::LAnd),
             ("or", Token::LOr),
@@ -346,7 +354,10 @@ impl<I: Iterator<Item = u8>> Lexer<I> {
                 let span = Span::new(start, end);
                 let st = String::from_utf8(st)
                     .map_err(|err| LexerError::StrLitInvalidUtf8(self.src.clone(), span, err))?;
-                return Ok(Lexeme::new(Token::StringLit(self.process_str_buf(st)), span));
+                return Ok(Lexeme::new(
+                    Token::StringLit(self.process_str_buf(st)),
+                    span,
+                ));
             }
             if s == b'\\' {
                 // should be made into its own error

--- a/ferric/src/lib.rs
+++ b/ferric/src/lib.rs
@@ -31,7 +31,9 @@ mod tests {
 
         let mut output = vec![];
 
-        Interpreter::new(src.clone(), &mut output).interpret(&expr).unwrap();
+        Interpreter::new(src.clone(), &mut output)
+            .interpret(&expr)
+            .unwrap();
 
         String::from_utf8(output).expect("Program outputted invalid utf8")
     }

--- a/ferric/src/parser.rs
+++ b/ferric/src/parser.rs
@@ -648,7 +648,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                             span: lexeme.span,
                             kind: ExprKind::VarGet { depth, slot },
                         },
-                        self.env[depth].typs[slot].clone(),
+                        self.env[self.env.len() - depth - 1].typs[slot].clone(),
                     )
                 },
             ),
@@ -666,6 +666,7 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                 )
             }
             Token::While => self.parse_while(lexeme.span)?,
+            Token::For => self.parse_for(lexeme.span)?,
             _ => {
                 return Err(ParserError::Unexpected {
                     src: self.src.clone(),
@@ -841,6 +842,46 @@ impl<I: Iterator<Item = Result<Lexeme, LexerError>>> Parser<I> {
                     body,
                 },
                 span: while_span + close,
+            },
+            Typ::Null,
+        ))
+    }
+
+    fn parse_for(&mut self, for_span: Span) -> Res<(Expr, Typ)> {
+        self.env.push(EnvStackFrame::new());
+        let (init, _) = self.parse_expr()?;
+        self.consume(Token::Semi, "Expected ';' after for loop init")?;
+        let (cond, cond_typ) = self.parse_expr()?;
+        assert!(
+            &cond_typ.can_coerce(&Typ::Bool),
+            "conditions must be a boolean"
+        );
+        self.consume(Token::Semi, "Expected ';' after for loop condition")?;
+
+        self.env.push(EnvStackFrame::new());
+        let (update, _) = self.parse_expr()?;
+
+        let open = self.consume(Token::OpenBracket, "Expected '{' after 'for'")?;
+
+        let (body, close, _) = self.parse_block(EnvStackFrame::new())?;
+
+        let inner = Expr {
+            kind: ExprKind::While {
+                cond: Box::new(cond),
+                body: vec![
+                    Expr {
+                        kind: ExprKind::Block(body),
+                        span: open.span + close,
+                    },
+                    update,
+                ],
+            },
+            span: for_span + close,
+        };
+        Ok((
+            Expr {
+                kind: ExprKind::Block(vec![init, inner]),
+                span: for_span + close,
             },
             Typ::Null,
         ))


### PR DESCRIPTION
This commit implements the desugaring of `for` loops into `while` loops.

# New
## parser
### parse_for
The new function `parse_for` desugars a for loop with syntax `for <init>; <cond>; <update> { <body> }` into a while loop. Everything is wrapped in stack frames to avoid clobbering other variables.

## lexer
### for token
A new token `for` has been added to the lexer's vocabulary.

# Bugs
## parser
### parse_basic
Fixed a bug in `parse_basic` which resulted in variable lookup occuring from the bottom of the environment stack instead of the top.

# Misc
`cargo fmt` formatted a couple of files which were not otherwise changed.